### PR TITLE
various bug fixes, optimizations, and feature implementations

### DIFF
--- a/CelesteBot-Everest-Interop/CelesteBotInteropModule.cs
+++ b/CelesteBot-Everest-Interop/CelesteBotInteropModule.cs
@@ -47,7 +47,7 @@ namespace CelesteBot_Everest_Interop
         public static bool ShowNothing = false;
 
         // Learning
-        public static LearningStyle LearningStyle = LearningStyle.Q;
+        public static LearningStyle LearningStyle = LearningStyle.NEAT;
 
         public static bool ShowBest = false;
         public static bool RunBest = false;
@@ -55,10 +55,11 @@ namespace CelesteBot_Everest_Interop
         public static int UpToSpecies = 0;
         public static bool ShowBestEachGen = false;
         public static int UpToGen = 0;
+        public static int FrameLoops = 1;
 
         public static CelestePlayer SpeciesChamp;
         public static CelestePlayer GenPlayerTemp;
-
+        
         private static int TalkCount = 0; // Counts how many times we attempted to talk to something
         private static int TalkMaxAttempts = 30; // How many attempts until we give up attempting to talk to something
         private static int MaxTimeSinceLastTalk = 100; // Number of skipped frames when we can talk if we have recently talked to something
@@ -391,6 +392,14 @@ namespace CelesteBot_Everest_Interop
             {
                 ShowNothing = true;
             }
+            else if (IsKeyDown(Keys.F) && IsKeyDown(Keys.LeftShift))
+            {
+                FrameLoops = 1;
+            }
+            else if (IsKeyDown(Keys.F))
+            {
+                FrameLoops = 4;
+            }
             if (state == State.Running)
             {
                 if (buffer > 0)
@@ -591,7 +600,11 @@ namespace CelesteBot_Everest_Interop
             //{
             //    // Player has not been setup yet
             //}
-            original(self, gameTime);
+            
+            for (int i = 0; i < FrameLoops; i++)
+            {
+                original(self, gameTime);
+            }
         }
         public static void OnScene_Transition(On.Celeste.Celeste.orig_OnSceneTransition original, Celeste.Celeste self, Scene last, Scene next)
         {

--- a/CelesteBot-Everest-Interop/CelesteBotManager.cs
+++ b/CelesteBot-Everest-Interop/CelesteBotManager.cs
@@ -40,7 +40,7 @@ namespace CelesteBot_Everest_Interop
         //public static int POPULATION_SIZE = 50;
 
         public static int PLAYER_GRACE_BUFFER = 160; // How long between restarts should the next player be created, some arbitrary number of frames
-        public static double PLAYER_DEATH_TIME_BEFORE_RESET = 2.5; // How many seconds after a player dies should the next player be created and the last one deleted
+        public static double PLAYER_DEATH_TIME_BEFORE_RESET = 4; // How many seconds after a player dies should the next player be created and the last one deleted
 
         // Paths/Prefixes
         public static string ORGANISM_PATH = @"organismNames.txt";
@@ -97,7 +97,7 @@ namespace CelesteBot_Everest_Interop
             //POPULATION_SIZE = 50;
 
             PLAYER_GRACE_BUFFER = 160; // How long between restarts should the next player be created, some arbitrary number of frames
-            PLAYER_DEATH_TIME_BEFORE_RESET = 2.5; // How many seconds after a player dies should the next player be created and the last one deleted
+            PLAYER_DEATH_TIME_BEFORE_RESET = 4; // How many seconds after a player dies should the next player be created and the last one deleted
     }
 
         public static void Draw()
@@ -411,6 +411,7 @@ namespace CelesteBot_Everest_Interop
 
                             renderPos -= TileFinder.GetCelesteLevel().Camera.Position;
                             renderPos *= 6f;
+
                             double tileWidth = 48;
                             double tileHeight = 48;
 
@@ -602,7 +603,8 @@ namespace CelesteBot_Everest_Interop
                     {
                         thickness = 6;
                     }
-                    Monocle.Draw.Circle(n.DrawPos, n.DrawRadius, color, thickness, 100);
+                    //Monocle.Draw.Circle(n.DrawPos, n.DrawRadius, color, thickness, 100);
+                    Monocle.Draw.Rect(n.DrawPos.X, n.DrawPos.Y, n.DrawRadius, n.DrawRadius, color);
                     //ActiveFont.Draw(Convert.ToString(n.Id), new Vector2(n.DrawPos.X - TEXT_OFFSET.X, n.DrawPos.Y - TEXT_OFFSET.Y), Vector2.Zero, NODE_LABEL_SCALE, color);
                     if (Labels.ContainsKey(n.Id))
                     {

--- a/CelesteBot-Everest-Interop/ConnectionHistory.cs
+++ b/CelesteBot-Everest-Interop/ConnectionHistory.cs
@@ -4,19 +4,27 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
+    [KnownType(typeof(ConnectionHistory))]
+    [DataContract]
     public class ConnectionHistory
     {
+        [DataMember]
         public static int NextConnectionInnovationNumber = 100;
 
+        [DataMember]
         public int FromNode; // Start
+        [DataMember]
         public int ToNode; // Finish
+        [DataMember]
         public int InnovationNumber; // Original innovation number
 
         // This array is _essentially_ a Genome copy.
         // It stores all of the innovation numbers of the Genome for when the mutation first occurred.
+        [DataMember]
         ArrayList originalGenomeCopy = new ArrayList();
         //the innovation Numbers from the connections of the genome which first had this mutation 
         //this represents the genome and allows us to test if another genome is the same

--- a/CelesteBot-Everest-Interop/GeneConnection.cs
+++ b/CelesteBot-Everest-Interop/GeneConnection.cs
@@ -3,19 +3,26 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
     // This class represents a Connection between two Nodes (refered to as a Gene)
     // This is essentially a weight.
+    [DataContract]
     public class GeneConnection
     {
+        [DataMember]
         public Node FromNode;
+        [DataMember]
         public Node ToNode;
+        [DataMember]
         public float Weight;
+        [DataMember]
         public bool Enabled = true;
+        [DataMember]
         public int InnovationNo; // This is essentially an ID to compare various Genomes, it is used to compare similarities and differences between Genomes.
-
+        
         public GeneConnection(Node from, Node to, float w, int inno)
         {
             FromNode = from;

--- a/CelesteBot-Everest-Interop/Genome.cs
+++ b/CelesteBot-Everest-Interop/Genome.cs
@@ -6,24 +6,41 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections;
 using Celeste.Mod;
+using System.Xml.Serialization;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
     // The Genome (Brain) for each Player.
     // This acts as the network, as well as contains various helper genetic functions.
+    [KnownType(typeof(GeneConnection))]
+    [DataContract]
     public class Genome
     {
+        [DataMember]
         public ArrayList Genes = new ArrayList(); // All of the connections between Nodes
+        [DataMember]
         public ArrayList Nodes = new ArrayList(); // All of the Nodes, in no particular order
+        [DataMember]
         public int Inputs;
+        [DataMember]
         public int Outputs;
+        [DataMember]
         public int Layers = 2; // Default 2, increases as evolution occurs
+        [DataMember]
         public int NextNode = 0; // The next Node ID to modify
+        [DataMember]
         public int BiasNode; // The Node ID that represents the bias Node
+        [DataMember]
         private Node bNode;
 
+        [DataMember]
         public ArrayList network = new ArrayList();//a list of the nodes in the order that they need to be considered in the NN
 
+        public Genome()
+        {
+
+        }
         public Genome(int inp, int outp)
         {
             // Set input number and output number

--- a/CelesteBot-Everest-Interop/Node.cs
+++ b/CelesteBot-Everest-Interop/Node.cs
@@ -5,20 +5,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
     // This class represents a Node (or a neuron)
+    [KnownType(typeof(Node))]
+    [DataContract(IsReference = true)]
     public class Node
     {
+        [DataMember]
         public int Id; // The ID of the Node (neuron), which is ALWAYS unique
+        [DataMember]
         public float InputSum = 0; // rewriten by all Nodes (neurons) that have this node (neuron) as an output. This is before activation.
+        [DataMember]
         public float OutputValue = 0; // Output value to send to all Output Nodes (neurons)
+        [DataMember]
         public ArrayList OutputConnections = new ArrayList(); // All of the outputs of this Node (neuron)
+        [DataMember]
         public int Layer = 0; // Where is the Node (neuron)? Layer 0 = input, Layer LAST = output
+        [DataMember]
         public Vector2 DrawPos = new Vector2(); // For drawing (Genome)
+        [DataMember]
         public int DrawRadius = 0;
-
+        
         public Node(int no)
         {
             // Only ID is set on construction, everything else is mutated externally as Genome sees fit

--- a/CelesteBot-Everest-Interop/Population.cs
+++ b/CelesteBot-Everest-Interop/Population.cs
@@ -5,25 +5,36 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
     // This class represents ALL of the Players that will be evolved.
     // It serves as a 'holder' for all of the Players of each generation and is also responsible for evolving them+showing+updating them
-    [Serializable]
+    [DataContract]
     public class Population
     {
+        [DataMember]
         public ArrayList Pop = new ArrayList();
+        [DataMember]
         public CelestePlayer BestPlayer;// The best player in the population 
+        [DataMember]
         public float BestFitness = 0;// The score of the best ever player
+        [DataMember]
         public int Gen;
+        [DataMember]
         public ArrayList InnovationHistory = new ArrayList();
+        [DataMember]
         public ArrayList GenPlayers = new ArrayList();
+        [DataMember]
         public ArrayList Species = new ArrayList();
 
+        [DataMember]
         bool massExtinctionEvent = false;
+        [DataMember]
         bool newStage = false;
 
+        [DataMember]
         public int CurrentIndex = 0;
 
         public Population(int size)

--- a/CelesteBot-Everest-Interop/Species.cs
+++ b/CelesteBot-Everest-Interop/Species.cs
@@ -5,23 +5,36 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.Serialization;
 
 namespace CelesteBot_Everest_Interop
 {
     // This class represents a Species of Genomes (Genomes that are comparable to each other)
+    [KnownType(typeof(Species))]
+    [DataContract]
     public class Species
     {
+        [DataMember]
         public ArrayList Players = new ArrayList();
+        [DataMember]
         public float BestFitness = 0;
+        [DataMember]
         public String Name;
+        [DataMember]
         public CelestePlayer Champ;
+        [DataMember]
         public float AverageFitness = 0;
+        [DataMember]
         public int Staleness = 0;//how many generations the species has gone without an improvement
+        [DataMember]
         public Genome Rep;
 
         // Coefficients for testing compatibility 
+        [DataMember]
         float excessCoeff = 1;
+        [DataMember]
         float weightDiffCoeff = 0.5f;
+        [DataMember]
         float compatibilityThreshold = 3;
 
 

--- a/CelesteBot-Everest-Interop/TileFinder.cs
+++ b/CelesteBot-Everest-Interop/TileFinder.cs
@@ -10,6 +10,14 @@ using System.Threading.Tasks;
 
 namespace CelesteBot_Everest_Interop
 {
+    public enum Entity : int
+    {
+        Unset = 0,
+        Air = 1,
+        Tile = 2,
+        Other = 4,
+        Spike = 8,
+    }
     public class TileFinder
     {
         private static Level celesteLevel;
@@ -17,6 +25,10 @@ namespace CelesteBot_Everest_Interop
         public static MTexture[,] tileArray;
 
         public static Vector2 TilesOffset = new Vector2(0,0); // TilesOffset for SolidsData offset
+
+        private static Vector2 cacheOffset = new Vector2(2, 1);
+        private static Entity[,,] cache = new Entity[4, 2, 2];
+
         public static void GetAllEntities()
         {
             EntityList entities = Celeste.Celeste.Scene.Entities;
@@ -82,7 +94,7 @@ namespace CelesteBot_Everest_Interop
         public static Vector2 GetTileXY(Vector2 realPos)
         {
             int tileW = 8, tileH = 8;
-            return new Vector2((int)((realPos.X - TilesOffset.X) / tileW), (int)((realPos.Y - TilesOffset.Y) / tileH));
+            return new Vector2((int)Math.Floor((realPos.X - TilesOffset.X) / tileW), (int)Math.Floor((realPos.Y - TilesOffset.Y) / tileH));
         }
         public static Vector2 RealFromTile(Vector2 tile)
         {
@@ -205,6 +217,141 @@ namespace CelesteBot_Everest_Interop
             {
                 return false;
             }
+        }
+        public static Entity GetEntityAtTile(Vector2 tile)
+        {
+            int xind = (int)(cacheOffset.X + tile.X);
+            int yind = (int)(cacheOffset.Y + tile.Y);
+            while(xind < 0 || xind >= cache.GetLength(0) || yind < 0 || yind >= cache.GetLength(1))
+            {
+                ScaleCache();
+                xind = (int)(cacheOffset.X + tile.X);
+                yind = (int)(cacheOffset.Y + tile.Y);
+            }
+            
+            if (cache[xind, yind, 0] == Entity.Unset)
+            {
+                EntityList entities = Celeste.Celeste.Scene.Entities;
+                Vector2 real = RealFromTile(tile);
+                for (int i = 0; i < entities.Count; i++)
+                {
+                    if (entities[i] is SolidTiles && entities[i].Collidable && entities[i].CollideRect(new Rectangle((int)real.X, (int)real.Y, 8, 8)))
+                    {
+                        cache[xind, yind, 0] = Entity.Tile;
+                    }
+                }
+                if (cache[xind, yind, 0] == Entity.Unset)
+                {
+                    cache[xind, yind, 0] = Entity.Air;
+                }
+            }
+            
+            if(cache[xind, yind, 0] == Entity.Tile)
+            {
+                //Logger.Log(LogLevel.Debug, "BOT_TEST", cache[xind, yind, 0].ToString() + " at " + xind.ToString() + ", " + yind.ToString() + ", 0");
+                return cache[xind, yind, 0];
+            }
+            else if(cache[xind, yind, 1] != Entity.Unset)
+            {
+                //Logger.Log(LogLevel.Debug, "BOT_TEST", cache[xind, yind, 1].ToString() + " at " + xind.ToString() + ", " + yind.ToString() + ", 1");
+                return cache[xind, yind, 1];
+            }
+            else
+            {
+                //Logger.Log(LogLevel.Debug, "BOT_TEST", cache[xind, yind, 0].ToString() + " at " + xind.ToString() + ", " + yind.ToString() + ", 0");
+                return cache[xind, yind, 0];
+            }
+        }
+        public static void UpdateGrid()
+        {
+            try
+            {
+                celesteLevel = (Level)Celeste.Celeste.Scene;
+            }
+            catch(Exception e)
+            {
+                return;
+            }
+            if(tiles != celesteLevel.SolidTiles)
+            {
+                tiles = celesteLevel.SolidTiles;
+                tileArray = tiles.Tiles.Tiles.ToArray();
+            }
+
+        }
+        public static void CacheEntities()
+        {
+            for (int i = 0; i < cache.GetLength(0); i++)
+            {
+                for (int j = 0; j < cache.GetLength(1); j++)
+                {
+                    cache[i, j, 1] = Entity.Unset;
+                }
+            }
+
+            EntityList entities = Celeste.Celeste.Scene.Entities;
+            for (int i = 0; i < entities.Count; i++)
+            {
+                if(entities[i].Collidable && entities[i].Collider != null && !(entities[i] is SolidTiles) && !(entities[i] is Player))
+                {
+                    //Logger.Log(LogLevel.Debug, "BOT_TEST", entities[i].GetType().ToString());
+                    Entity type = Entity.Other;
+                    if(entities[i] is Spikes)
+                    {
+                        type = Entity.Spike;
+                    }
+                    Rectangle rect = entities[i].Collider.Bounds;
+                    //Logger.Log(LogLevel.Debug, "BOT_TEST", rect.Left.ToString() + " " + rect.Right.ToString() + " " + rect.Bottom.ToString() + " " + rect.Top.ToString());
+                    int j = rect.Left;
+                    if(j % 8 == 0)
+                    {
+                        j += 1;
+                    }
+                    for (; j < rect.Right; j += 8)
+                    {
+                        int k = rect.Top;
+                        if (k % 8 == 0)
+                        {
+                            k += 1;
+                        }
+                        for (; k < rect.Bottom; k += 8)
+                        {
+                            //Logger.Log(LogLevel.Debug, "BOT_TEST", j.ToString() + " " + k.ToString());
+                            Vector2 tile = GetTileXY(new Vector2(j, k));
+                            int xind = (int)(cacheOffset.X + tile.X);
+                            int yind = (int)(cacheOffset.Y + tile.Y);
+                            while (xind < 0 || xind >= cache.GetLength(0) || yind < 0 || yind >= cache.GetLength(1))
+                            {
+                                ScaleCache();
+                                xind = (int)(cacheOffset.X + tile.X);
+                                yind = (int)(cacheOffset.Y + tile.Y);
+                            }
+                            cache[xind, yind, 1] = type;
+                            //Logger.Log(LogLevel.Debug, "BOT_TEST", cache[xind, yind, 1].ToString() + " cached at " + xind.ToString() + ", " + yind.ToString() + ", 1");
+                            //Logger.Log(LogLevel.Debug, "BOT_TEST", cache[xind, yind, 0].ToString() + " cached at " + xind.ToString() + ", " + yind.ToString() + ", 0");
+                        }
+                    }
+                }
+            }
+        }
+        public static void ScaleCache()
+        {
+            Entity[,,] newCache = new Entity[2 * cache.GetLength(0), 2 * cache.GetLength(1), 2];
+
+            int xoff = (int)cacheOffset.X;
+            int yoff = (int)cacheOffset.Y;
+
+            for(int i = 0; i < cache.GetLength(0); i++)
+            {
+                for(int j = 0; j < cache.GetLength(1); j++)
+                {
+                    newCache[xoff + i, yoff + j, 0] = cache[i, j, 0];
+                    newCache[xoff + i, yoff + j, 1] = cache[i, j, 1];
+                }
+            }
+
+            cache = newCache;
+            cacheOffset *= 2;
         }
         //public static MTexture[,] GetSplicedTileArray(int visionX, int visionY)
         //{

--- a/CelesteBot-Everest-Interop/Util.cs
+++ b/CelesteBot-Everest-Interop/Util.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Serialization;
+using System.Runtime.Serialization.Json;
 
 namespace CelesteBot_Everest_Interop
 {
@@ -26,15 +27,17 @@ namespace CelesteBot_Everest_Interop
             {
                 using (Stream stream = File.Create(fileName))
                 {
-                    IFormatter formatter = new BinaryFormatter();
-                    formatter.Serialize(stream, pop);
+                    DataContractSerializerSettings settings = new DataContractSerializerSettings();
+                    settings.KnownTypes = new List<Type> { typeof(CelestePlayer), typeof(ConnectionHistory), typeof(GeneConnection), typeof(Genome), typeof(Node), typeof(Population), typeof(Species) };
+                    DataContractSerializer serializer = new DataContractSerializer(typeof(Population), settings);
+                    serializer.WriteObject(stream, pop);
                     stream.Close();
                 }
             }
             catch (Exception ex)
             {
                 Logger.Log(CelesteBotInteropModule.ModLogKey, "An exception happened when attempting to save a checkpoint!");
-                Logger.Log(CelesteBotInteropModule.ModLogKey, ex.Message);
+                Logger.Log(CelesteBotInteropModule.ModLogKey, ex.ToString());
             }
         }
         public static Population DeSerializeObject(string fileName)
@@ -47,16 +50,18 @@ namespace CelesteBot_Everest_Interop
             {
                 using (Stream stream = File.OpenRead(fileName))
                 {
-                    IFormatter formatter = new BinaryFormatter();
+                    DataContractSerializerSettings settings = new DataContractSerializerSettings();
+                    settings.KnownTypes = new List<Type> { typeof(CelestePlayer), typeof(ConnectionHistory), typeof(GeneConnection), typeof(Genome), typeof(Node), typeof(Population), typeof(Species) };
+                    DataContractSerializer serializer = new DataContractSerializer(typeof(Population), settings);
                     stream.Position = 0;
-                    objectOut = (Population)formatter.Deserialize(stream);
+                    objectOut = (Population)serializer.ReadObject(stream);
                     stream.Close();
                 }
             }
             catch (Exception ex)
             {
                 Logger.Log(CelesteBotInteropModule.ModLogKey, "An exception happened when attempting to load a checkpoint!");
-                Logger.Log(CelesteBotInteropModule.ModLogKey, ex.Message);
+                Logger.Log(CelesteBotInteropModule.ModLogKey, ex.ToString());
             }
 
             return objectOut;


### PR DESCRIPTION
add: fast mode (f and shift+f toggle normal game speed and 4x game speed), entity and tile caching (more efficient than collision detection every frame), neat population serialization (can save and load neat population data from file);

fix: real to tile off by one error when coordinates were negative, infinite fitness error when player was 0 distance from checkpoint, fitness not being calculated when brain was not showing, player not resetting correctly for a variety of reasons (player now ceases inputs after dying, this way they can't die again);

change: brain rendering (squares are more efficient to render than circles)

everything *should* work fine after this merge but if it doesn't, lmk and i can help fix anything that doesn't make sense